### PR TITLE
fix(hcvault): error on nil secret in extractPlaintext (AEAD contract parity)

### DIFF
--- a/integration/hcvault/hcvault_aead.go
+++ b/integration/hcvault/hcvault_aead.go
@@ -138,13 +138,20 @@ func (a *vaultAEAD) Encrypt(plaintext, associatedData []byte) ([]byte, error) {
 }
 
 func extractPlaintext(secret *api.Secret) ([]byte, error) {
-	// Note that when a valid ciphertext of the empty string is decrypted,
-	// secret.Data["plaintext"] may not be set. So we allow that.
+	// A nil response from Vault is never a successful Decrypt: the AEAD
+	// contract requires that a successful Decrypt produce authenticated
+	// data. extractCiphertext applies the same shape check on Encrypt;
+	// extractPlaintext was previously asymmetric and silently returned an
+	// empty byte slice on nil/missing fields, which lets a malformed or
+	// compromised Vault response be accepted as authenticated empty data.
 	if secret == nil {
-		return []byte{}, nil
+		return nil, errors.New("secret is nil")
 	}
 	p, ok := secret.Data["plaintext"]
 	if !ok {
+		// A missing "plaintext" field is the documented Vault encoding of
+		// "empty plaintext successfully decrypted"; preserve that exact
+		// edge case but reject the broader nil/missing-secret shape above.
 		return []byte{}, nil
 	}
 	plaintext64, ok := p.(string)

--- a/integration/hcvault/hcvault_aead_internal_test.go
+++ b/integration/hcvault/hcvault_aead_internal_test.go
@@ -164,6 +164,10 @@ func TestExtractPlaintextFails(t *testing.T) {
 		secret *api.Secret
 	}{
 		{
+			desc:   "nil secret",
+			secret: nil,
+		},
+		{
 			desc: "wrong type",
 			secret: &api.Secret{
 				Data: map[string]any{"plaintext": 123},


### PR DESCRIPTION
## Background

`extractPlaintext` silently returned `(nil, nil)` on a `nil` Vault response, while the sibling `extractCiphertext` errors on the same shape. The asymmetry lets a malformed or compromised Vault response be accepted as authenticated empty plaintext by AEAD callers that follow the canonical `if err == nil { trust(plaintext) }` pattern — i.e. the AEAD contract is broken on the Decrypt side.

## Change

- `extractPlaintext` errors on nil secret, matching `extractCiphertext` shape
- Documented Vault edge case (missing `plaintext` field for empty-plaintext decrypt) is preserved
- Adds a `nil secret` case to `TestExtractPlaintextFails`

## Threat model

Vault transit API failure modes can cause an HTTP 200 success with a nil/missing secret payload. With the previous behavior, a tink-go-hcvault `Decrypt` call returns `(nil, nil)` to the AEAD caller in that case, and the caller treats `nil` plaintext as authenticated. After this fix it returns an error, matching `extractCiphertext`'s shape and the AEAD contract.